### PR TITLE
implement rate limiting for message sending in IRC bot

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,7 +54,7 @@ export default {
   rateLimit: {
     enabled: true,
     maxMessages: 5, // Maximum messages per interval
-    intervalMs: 60_000, // Interval in milliseconds (5 messages per minute = 60,000ms)
+    intervalMs: 60_000, // Interval in milliseconds (60,000ms = 1 minute or 60 seconds)
   },
 } satisfies {
   channels: Channels;

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,6 +51,11 @@ export default {
   },
   feeds,
   hexip: false, // enable hexip? Probably false unless you know what you're doing.
+  rateLimit: {
+    enabled: true,
+    maxMessages: 5, // Maximum messages per interval
+    intervalMs: 60_000, // Interval in milliseconds (5 messages per minute = 60,000ms)
+  },
 } satisfies {
   channels: Channels;
   server: string;
@@ -61,4 +66,9 @@ export default {
   };
   feeds: Feeds;
   hexip: boolean;
+  rateLimit: {
+    enabled: boolean;
+    maxMessages: number;
+    intervalMs: number;
+  };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,10 +100,11 @@ const init_feeder = () => {
   Object.entries(config.feeds).forEach(([eventName, { url, refresh }]) => {
     feeder.on(eventName, (item) => {
       match_channels(eventName as Feed).forEach((channel) => {
-        rateLimitedSay(
-          channel,
-          `${c.blue(item.title)} - ${item.link} by ${getAuthors(item)}`
-        );
+        const authors = getAuthors(item);
+        const message = authors
+          ? `${c.blue(item.title)} - ${item.link} by ${authors}`
+          : `${c.blue(item.title)} - ${item.link}`;
+        rateLimitedSay(channel, message);
       });
     });
     feeder.add({ url, refresh, eventName });

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,9 @@ function getAuthors(item: Item) {
 
   if (Array.isArray(item["rss:author"])) {
     const authors = item["rss:author"].map((author) => author.name["#"]);
+    if (authors.length === 0) return "";
+    if (authors.length === 1) return authors[0];
+
     const lastAuthor = authors.pop();
     return `${authors.join(", ")} and ${lastAuthor}`;
   }


### PR DESCRIPTION
This pull request introduces a configurable rate limiting feature for outgoing IRC messages and improves the formatting of author information in feed announcements. The rate limiter helps prevent the bot from sending too many messages in a short period, and the author formatting now handles edge cases more gracefully.

**Rate limiting enhancements:**

* Added a `rateLimit` configuration section in `src/config.ts` to enable/disable rate limiting and set the maximum number of messages and interval duration. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R54-R58) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R69-R73)
* Implemented a `rateLimitedSay` function in `src/index.ts` that enforces the configured message rate limit, dropping messages that exceed the limit. All outgoing messages now use this function. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R10-R37) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L72-R107)

**Feed author formatting improvements:**

* Updated the `getAuthors` function in `src/index.ts` to return cleaner output: it now returns an empty string if there are no authors, a single name if there is only one author, or a properly formatted list if there are multiple authors.