### PR TITLE
enhance item storage by adding channel support 

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "all",
+  "singleQuote": false,
+  "semi": true,
+  "printWidth": 80
+}
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "workbench.colorCustomizations": {
+    "titleBar.activeForeground": "#e0e7ff",
+    "titleBar.inactiveForeground": "#a5b4fc",
+    "titleBar.activeBackground": "#4f46e5",
+    "titleBar.inactiveBackground": "#312e81"
+  },
+  "biome.enabled": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,18 @@
     "titleBar.activeBackground": "#4f46e5",
     "titleBar.inactiveBackground": "#312e81"
   },
-  "biome.enabled": false
+  "biome.enabled": false,
+  "eslint.enable": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "prettier.enable": true,
+    "biome.enabled": false
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "prettier.enable": true,
+    "biome.enabled": false
+  },
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,8 @@
 import eslint from "apekit/lint";
 
-export default eslint(import.meta.dirname);
+export default [
+  ...eslint(import.meta.dirname),
+  {
+    ignores: ["eslint.config.js"],
+  },
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const Item = new Store(
     feed: p.string,
     channel: p.string,
   },
-  { database: sqlite({ database: "./db.data" }), name: "item" }
+  { database: sqlite({ database: "./db.data" }), name: "item" },
 );
 Item.schema.create();
 


### PR DESCRIPTION
This pull request introduces configuration improvements and refactors how feed items are stored and processed in the IRC bot. The main changes include adding new formatting and linting settings, updating the item schema to track channels, and ensuring feed links are stored and announced per channel to avoid duplicate messages.

**Configuration and formatting updates:**

* Added a `.prettierrc.json` file to enforce consistent code formatting, including trailing commas, semicolons, and a set print width.
* Updated `.vscode/settings.json` to enable Prettier and ESLint for TypeScript and JavaScript, disable Biome, and customize the editor color theme.
* Modified `eslint.config.js` to ignore itself during linting.

**Feed item storage and processing refactor:**

* Updated the `Item` schema in `src/index.ts` to include a `channel` field, allowing items to be tracked per channel.
* Refactored the RSS feed handler to check and store items per channel, ensuring that links are only announced in a channel if they haven't been posted there before. This prevents duplicate announcements and supports multi-channel feeds.