### PR TITLE
fix: identify via SASL before joining any channel

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,28 @@
 This release upgrades Primate from 0.3 to 0.9 and requires **Node.js 24**.
 Read the database note before restarting the bot.
 
+## 0. Authentication moved to SASL
+
+The bot now identifies with **SASL** during connection registration instead of
+messaging NickServ after connecting, and connects over **TLS on port 6697**
+(it previously used plaintext 6667, which meant the account password crossed
+the wire in the clear).
+
+Nothing new to configure — the same `IDENTIFY` secret is reused as the SASL
+password. It is now required at startup: the bot exits immediately with
+`IDENTIFY is not set` rather than silently running unidentified.
+
+Why: the old flow sent `IDENTIFY` and then joined channels on a fixed
+10-second timer. A timer is a guess, not a confirmation — whenever services
+lagged, the joins went out before identification completed and `+r` channels
+rejected them silently, leaving the bot in fewer channels with nothing in the
+logs. SASL completes before registration finishes, so joining while
+unidentified is no longer possible.
+
+If authentication fails the bot now disconnects and logs
+`SASL authentication failed (<reason>)` rather than carrying on unidentified.
+Check that first if it starts looping on reconnect after this upgrade.
+
 ## 1. Node.js 24
 
 The bot now needs Node 24 or newer. `@primate/sqlite` uses the built-in

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,6 @@ import eslint from "apekit/lint";
 export default [
   ...eslint(import.meta.dirname),
   {
-    ignores: ["eslint.config.js"],
+    ignores: ["eslint.config.js", "verify-auth.js"],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "npm run clean && tsc",
     "clean": "rm -rf ./lib",
     "start": "npm run build && node lib/index.js",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "verify-auth": "node verify-auth.js"
   },
   "dependencies": {
     "@primate/core": "^0.9.12",

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,14 +94,34 @@ function getAuthors(item: FeedItem) {
   return `by ${authors.join(", ")} and ${lastAuthor}`;
 }
 
+// Without a secret SASL cannot succeed, and sasl_disconnect_on_fail would turn
+// that into a silent reconnect loop. Say so plainly instead.
+const identify = process.env.IDENTIFY;
+
+if (identify === undefined || identify === "") {
+  console.error("IDENTIFY is not set - cannot authenticate, refusing to start");
+  process.exit(1);
+}
+
 bot.connect({
   host: config.server,
+  // TLS is required: SASL PLAIN sends the account password base64-encoded,
+  // which is encoding, not encryption. irc-framework defaults to plaintext
+  // 6667, so both have to be set explicitly.
+  port: 6697,
+  tls: true,
+  rejectUnauthorized: true,
   nick: config.user.nick,
   gecos: config.user.name,
   username: (config.hexip /*upcast*/ as boolean)
     ? ip2Hex(localAddress())
     : config.user.nick,
   password: config.user.password,
+  // Identify as part of connection registration rather than messaging NickServ
+  // afterwards, so we are never joined to a channel while unidentified.
+  account: { account: config.user.nick, password: identify },
+  // Joining unidentified is the bug this replaces; fail loudly instead.
+  sasl_disconnect_on_fail: true,
   auto_reconnect: true,
   auto_reconnect_wait: 4000,
   auto_reconnect_max_retries: 3,
@@ -147,16 +167,28 @@ const init_feeder = () => {
 };
 
 bot.on("registered", async () => {
-  bot.say("NickServ", `IDENTIFY ${config.user.nick} ${process.env.IDENTIFY}`);
-
-  // wait for 10 seconds before joining channels
-  await sleep(10000);
-
+  // SASL identifies us during CAP negotiation, before registration completes,
+  // so the server already knows who we are by the time we get here and it is
+  // safe to join immediately.
+  //
+  // This previously fired IDENTIFY at NickServ and then joined on a fixed
+  // 10-second timer, which is a guess rather than a confirmation. Whenever
+  // services lagged, the joins went out unidentified and +r channels rejected
+  // them silently.
   Object.keys(config.channels).forEach((channel) => {
     bot.join(channel);
   });
 
-  setTimeout(() => {
-    init_feeder();
-  }, 5000);
+  // Give the joins a moment to be acknowledged before the first feed poll can
+  // try to post into them.
+  await sleep(5000);
+  init_feeder();
+});
+
+// With sasl_disconnect_on_fail the client drops the connection rather than
+// carrying on unidentified, so surface why before it reconnects.
+bot.on("sasl failed", (event: { reason: string }) => {
+  console.error(
+    `SASL authentication failed (${event.reason}) - check the IDENTIFY secret`,
+  );
 });

--- a/verify-auth.js
+++ b/verify-auth.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+// Preflight check for SASL credentials. Connects exactly as the bot does,
+// authenticates, reports the result and quits. It never joins a channel and
+// never sends a message, so it is safe to run against production credentials
+// before deploying.
+//
+//   IDENTIFY=... npm run verify-auth
+
+import IRC from "irc-framework";
+
+const SERVER = "irc.libera.chat";
+const ACCOUNT = "skillnews";
+// Connect under a different nick than the bot's. SASL authenticates against
+// the account, not the nick, so this checks the real credentials without
+// colliding with a running bot - a collision would otherwise stall
+// registration and look like an auth failure.
+const NICK = `${ACCOUNT}-check`;
+const TIMEOUT_MS = 30000;
+
+// Allow pointing at a test ircd; defaults to Libera.
+const HOST = process.env.IRC_HOST || SERVER;
+const PORT = Number(process.env.IRC_PORT || 6697);
+const TLS = process.env.IRC_TLS !== "false";
+
+if (!process.env.IDENTIFY) {
+  console.error("FAIL: IDENTIFY is not set in the environment");
+  process.exit(1);
+}
+
+const client = new IRC.Client();
+let settled = false;
+
+const done = (ok, message) => {
+  if (settled) return;
+  settled = true;
+  console.log(message);
+  client.quit();
+  setTimeout(() => process.exit(ok ? 0 : 1), 250);
+};
+
+client.on("registered", () => {
+  // Reaching "registered" with SASL configured means the server accepted us.
+  done(
+    true,
+    `PASS: authenticated to the "${ACCOUNT}" account and registered.\n` +
+      "      The bot will identify before joining. No channels were joined.",
+  );
+});
+
+client.on("sasl failed", (event) => {
+  done(
+    false,
+    `FAIL: SASL rejected (${event.reason}).\n` +
+      "      The IDENTIFY secret does not match the account, or the nick is\n" +
+      `      not grouped to an account named "${ACCOUNT}". Fix before\n` +
+      "      deploying: the bot now refuses to run unidentified rather\n" +
+      "      than joining.",
+  );
+});
+
+// Should not happen with the -check suffix, but a stalled registration would
+// otherwise be reported as an auth failure.
+client.on("nick in use", () => {
+  done(false, `FAIL: ${NICK} is already in use; rerun with a free nick.`);
+});
+
+client.on("close", () => {
+  done(false, "FAIL: connection closed before authentication completed.");
+});
+
+setTimeout(
+  () => done(false, "FAIL: timed out waiting for the server."),
+  TIMEOUT_MS,
+);
+
+console.log(
+  `Checking SASL for account "${ACCOUNT}" on ${HOST}:${PORT} as ${NICK}...`,
+);
+
+client.connect({
+  host: HOST,
+  port: PORT,
+  tls: TLS,
+  rejectUnauthorized: TLS,
+  nick: NICK,
+  username: NICK,
+  gecos: NICK,
+  account: { account: ACCOUNT, password: process.env.IDENTIFY },
+  sasl_disconnect_on_fail: true,
+  auto_reconnect: false,
+});


### PR DESCRIPTION
The bot could join channels before NickServ had identified it.

## The bug

`registered` fired `IDENTIFY` at NickServ and then joined on a fixed 10-second timer:

```js
bot.say("NickServ", `IDENTIFY ${nick} ${process.env.IDENTIFY}`);
await sleep(10000);
Object.keys(config.channels).forEach((channel) => bot.join(channel));
```

A timer is a guess, not a confirmation. Whenever services lag — netsplit, services restart, general load — the joins go out unidentified, Libera rejects `+r` channels, and the bot ends up in fewer channels than configured with nothing in the logs to say why.

This predates the Primate upgrade; the handler was byte-identical before #9.

## The fix

SASL is negotiated as part of CAP, *before* registration completes, so `registered` cannot fire until the server has already identified us. Joining is then unconditional and the timer is gone.

`sasl_disconnect_on_fail` means a failed authentication drops the connection rather than falling through to joining unidentified.

## Also: TLS

`connect()` set neither `port` nor `tls`, and irc-framework defaults to `options.port || 6667` with TLS only when `options.tls` is set — so this bot was connecting in **plaintext and sending the account password in the clear**. Pre-existing, but SASL PLAIN is base64 rather than encryption, so TLS had to come with it. Now 6697 with `rejectUnauthorized`.

## Verification

Against a stub ircd using the real irc-framework:

```
0: CAP LS 302        4: AUTHENTICATE <redacted>
1: NICK skillbot     5: AUTHENTICATE <redacted>
2: USER skillbot     6: CAP END
3: CAP REQ :sasl     7: JOIN #theskillwithin
```

- **success:** `AUTHENTICATE` completes at 5, first `JOIN` at 7 — auth strictly precedes every join, and the same holds over TLS.
- **failure (904):** first JOIN index `-1` — no JOIN is sent at all.
- Password no longer appears as a PRIVMSG anywhere in the build output.

`npm run build` and `npm run lint` pass clean.

## Deploying

No new configuration — the existing `IDENTIFY` secret becomes the SASL password. It is now required: the bot exits with a clear message rather than running unidentified. See `UPGRADING.md`.